### PR TITLE
fix: update changelog link for v1.8.12

### DIFF
--- a/announcements/index.html
+++ b/announcements/index.html
@@ -25,7 +25,7 @@ title: Fluent Bit - Articles
     </thead>
     <tbody>
       <tr>
-        <td><a href="/announcements/v1.8.11/">v1.8.12</a></td>
+        <td><a href="/announcements/v1.8.12/">v1.8.12</a></td>
         <td>Jan 24, 2021</td>
         <td><span class="badge badge-u">new</span></td>
       </tr>


### PR DESCRIPTION
Hi,

Just updated the link to the v1.8.12 changelog on the index page that was pointing the v1.8.11

Regards!